### PR TITLE
Enhance service observability

### DIFF
--- a/services/service_a/app/main.py
+++ b/services/service_a/app/main.py
@@ -1,35 +1,69 @@
-from fastapi import FastAPI
-from prometheus_fastapi_instrumentator import Instrumentator
+"""Service A application with observability configured."""
 
+from __future__ import annotations
+
+import os
+
+from fastapi import FastAPI, HTTPException
+from loguru import logger
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import \
+    OTLPSpanExporter
 from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+from opentelemetry.instrumentation.logging import LoggingInstrumentor
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
-from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from prometheus_fastapi_instrumentator import Instrumentator
 
 app = FastAPI(title="Service A")
 
-# Prometheus metrics
-Instrumentator().instrument(app).expose(app)
 
-# OpenTelemetry Tracing
-resource = Resource.create({"service.name": "service_a"})
-trace_provider = TracerProvider(resource=resource)
-trace_provider.add_span_processor(
-    BatchSpanProcessor(
-        OTLPSpanExporter(endpoint="http://otel-collector:4318/v1/traces")
+def configure_observability(application: FastAPI) -> None:
+    """Configure metrics, tracing and logging."""
+
+    # Prometheus metrics
+    Instrumentator().instrument(application).expose(application)
+
+    # OpenTelemetry tracing
+    resource = Resource.create({"service.name": "service_a"})
+    trace_provider = TracerProvider(resource=resource)
+
+    otlp_endpoint = os.environ.get(
+        "OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4318"
     )
-)
-FastAPIInstrumentor.instrument_app(app, tracer_provider=trace_provider)
+    trace_provider.add_span_processor(
+        BatchSpanProcessor(OTLPSpanExporter(endpoint=f"{otlp_endpoint}/v1/traces"))
+    )
+
+    FastAPIInstrumentor.instrument_app(application, tracer_provider=trace_provider)
+
+    # Structured logging
+    LoggingInstrumentor().instrument(set_logging_format=True)
+    logger.info("Observability configured")
+
+
+configure_observability(app)
 
 
 @app.get("/health")
-async def health():
+async def health() -> dict[str, str]:
+    """Simple healthcheck endpoint."""
+
     return {"status": "ok"}
 
 
 @app.get("/compute")
-async def compute(n: int = 10):
-    # Dummy CPU-intensive calculation
+async def compute(n: int = 10) -> dict[str, int]:
+    """Return the sum of squares up to ``n``.
+
+    Parameters
+    ----------
+    n: int
+        Upper bound for the calculation. Must be between 0 and 100000.
+    """
+
+    if n < 0 or n > 100_000:
+        raise HTTPException(status_code=400, detail="n must be between 0 and 100000")
+
     result = sum(i * i for i in range(n))
     return {"input": n, "result": result}

--- a/tests/test_service_a.py
+++ b/tests/test_service_a.py
@@ -1,0 +1,26 @@
+import os
+import sys
+
+from fastapi.testclient import TestClient
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "services"))
+from service_a.app.main import app
+
+client = TestClient(app)
+
+
+def test_health() -> None:
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}
+
+
+def test_compute_valid() -> None:
+    resp = client.get("/compute", params={"n": 5})
+    assert resp.status_code == 200
+    assert resp.json() == {"input": 5, "result": 30}
+
+
+def test_compute_invalid() -> None:
+    resp = client.get("/compute", params={"n": -1})
+    assert resp.status_code == 400


### PR DESCRIPTION
## Summary
- configure observability in a helper function
- use environment variables for OTLP endpoint
- add logging instrumentation
- validate compute input and add docstrings
- add basic tests for service A

## Testing
- `black --check services/service_a/app/main.py tests/test_service_a.py`
- `isort --check services/service_a/app/main.py tests/test_service_a.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686425969f64832c93692256567d1c51